### PR TITLE
Specify the initial branch for test repos.

### DIFF
--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -178,7 +178,8 @@ def init_git_repo(path):
     """
     start_cwd = os.getcwd()
     os.chdir(path)
-    assert run(["git", "init", "-b", "master", "."]).returncode == 0
+    assert run(["git", "init", "."]).returncode == 0
+    assert run(["git", "checkout", "-b", "master"]).returncode == 0
     assert run(["git", "config", "user.email", "alr@testing.com"]) \
         .returncode == 0
     assert run(["git", "config", "user.name", "Alire Testsuite"]) \

--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -178,7 +178,7 @@ def init_git_repo(path):
     """
     start_cwd = os.getcwd()
     os.chdir(path)
-    assert run(["git", "init", "."]).returncode == 0
+    assert run(["git", "init", "-b", "master", "."]).returncode == 0
     assert run(["git", "config", "user.email", "alr@testing.com"]) \
         .returncode == 0
     assert run(["git", "config", "user.name", "Alire Testsuite"]) \


### PR DESCRIPTION
  * testsuite/drivers/helpers.py (init_git_repo): specify the initial branch (to 'master', so match test suite assumptions).