### PR TITLE
Specify the initial branch for test repos.

### DIFF
--- a/testsuite/drivers/helpers.py
+++ b/testsuite/drivers/helpers.py
@@ -179,6 +179,9 @@ def init_git_repo(path):
     start_cwd = os.getcwd()
     os.chdir(path)
     assert run(["git", "init", "."]).returncode == 0
+    # You might think to init with --initial-branch=master, but
+    # e.g. Centos's git doesn't support this.
+    assert run(["git", "checkout", "-b", "master"]).returncode == 0
     assert run(["git", "config", "user.email", "alr@testing.com"]) \
         .returncode == 0
     assert run(["git", "config", "user.name", "Alire Testsuite"]) \


### PR DESCRIPTION
Reason: the git in macOS Xcode 14 defaults the initial branch to 'main', but the tests assume 'master'.

  * testsuite/drivers/helpers.py (init_git_repo): check out the branch 'master'.