### PR TITLE
MacOS; export PATH variables for includes and libraries.

### DIFF
--- a/src/alire/alire-platforms-current.ads
+++ b/src/alire/alire-platforms-current.ads
@@ -19,7 +19,8 @@ package Alire.Platforms.Current is
 
    procedure Load_Environment (Ctx : in out Alire.Environment.Context);
    --  Set environment variables from the platform. Used by Windows to
-   --  initialize msys2 environment.
+   --  initialize msys2 environment, and by macOS to initialize which,
+   --  if either, of the Homebrew or MacPorts environment.
 
    -----------------------
    --  Self identification

--- a/src/alire/os_macos/alire-platforms-current__macos.adb
+++ b/src/alire/os_macos/alire-platforms-current__macos.adb
@@ -1,19 +1,23 @@
+with Alire.Environment;
 with Alire.OS_Lib;
+with Ada.Directories;
 with GNAT.OS_Lib;
 
 package body Alire.Platforms.Current is
 
    --  macOS implementation
 
+   use type GNAT.OS_Lib.String_Access;
+
    --  Homebrew
-   Homebrew_Prefix : constant String
-     := Alire.OS_Lib.Getenv ("HOMEBREW_PREFIX", "");
-   Homebrew_Present : constant Boolean := Homebrew_Prefix /= "";
+
+   Brew_Access : constant GNAT.OS_Lib.String_Access
+     := GNAT.OS_Lib.Locate_Exec_On_Path ("brew");
+   Homebrew_Present : constant Boolean := Brew_Access /= null;
 
    --  MacPorts
    Port_Access : constant GNAT.OS_Lib.String_Access
      := GNAT.OS_Lib.Locate_Exec_On_Path ("port");
-   use type GNAT.OS_Lib.String_Access;
    Macports_Present : constant Boolean := Port_Access /= null;
 
    ------------------
@@ -21,26 +25,27 @@ package body Alire.Platforms.Current is
    ------------------
 
    function Detected_Distribution return Platforms.Distributions is
-   begin
-      if Homebrew_Present
-      then
-         return Homebrew;
-      elsif Macports_Present then
-         return Macports;
-      else
-         return Distro_Unknown;
-      end if;
-   end Detected_Distribution;
+     (if Homebrew_Present
+      then Homebrew
+      elsif Macports_Present
+      then Macports
+      else Distro_Unknown);
 
    -----------------------
    -- Distribution_Root --
    -----------------------
 
+   function Containing_Containing_Dir
+     (Executable : not null GNAT.OS_Lib.String_Access) return String
+     is (Ada.Directories.Containing_Directory
+           (Ada.Directories.Containing_Directory
+              (Executable.all)));
+
    function Distribution_Root return Absolute_Path
      is (if Homebrew_Present
-         then Homebrew_Prefix
+         then Containing_Containing_Dir (Brew_Access)
          elsif Macports_Present
-         then "/opt/local"
+         then Containing_Containing_Dir (Port_Access)
          else "/");
 
    ----------------------
@@ -48,7 +53,20 @@ package body Alire.Platforms.Current is
    ----------------------
 
    procedure Load_Environment (Ctx : in out Alire.Environment.Context)
-   is null;
+   is
+      Root : constant Absolute_Path := Distribution_Root;
+   begin
+      --  Set up paths if a distribution manager is present
+      if Homebrew_Present then
+         Ctx.Append ("C_INCLUDE_PATH", Root & "/include", "homebrew");
+         Ctx.Append ("CPLUS_INCLUDE_PATH", Root & "/include", "homebrew");
+         Ctx.Append ("LIBRARY_PATH", Root & "/lib", "homebrew");
+      elsif Macports_Present then
+         Ctx.Append ("C_INCLUDE_PATH", Root & "/include", "macports");
+         Ctx.Append ("CPLUS_INCLUDE_PATH", Root & "/include", "macports");
+         Ctx.Append ("LIBRARY_PATH", Root & "/lib", "macports");
+      end if;
+   end Load_Environment;
 
    ----------------------
    -- Operating_System --


### PR DESCRIPTION
Homebrew and MacPorts install include files and libraries in places where GCC won't look by default.

GCC will use these environment variables if set:

   C_INCLUDE_PATH     for C includes
   CPLUS_INCLUDE_PATH for C++ includes
   LIBRARY_PATH       for libraries

Both of the distribution managers place (symbolic links to) include files in ${top_level}/include and libraries in ${top_level}/lib.

   For Homebrew on Intel silicon, top_level is normally /usr/local.
   For Homebrew on Apple silicon, top_level is normally /opt/homebrew.
   For MacPorts,                  top_level is normally /opt/local

  * src/alire/alire-platforms-current.ads (Load_Environment): add note on macOS use.
  * src/alire/os_macos/alire-platforms-current__macos.adb (context): added Alire.Environment (was limited), Ada.Directories. (Brew_Access): new. (Homebrew_Present): if Brew_Access is not null. (Detected_Distribution): made into an expression function. (Containing_Containing_Dir): new, used in Distribution_Root. (Distribution_Root): reworked. (Load_Environment): if either distribution is present, arrange to export the environment variables to suit.